### PR TITLE
修复代理域名，解决PC端无法看图问题

### DIFF
--- a/plugin_image_finder/keyword.go
+++ b/plugin_image_finder/keyword.go
@@ -69,9 +69,9 @@ func init() {
 		Handle(func(ctx *zero.Ctx) {
 			keyword := ctx.State["regex_matched"].([]string)[1]
 			soutujson := soutuapi(keyword)
-			pom1 := "https://i.pixiv.cat"
+			pom1 := "https://i.pixiv.re"
 			rannum := randintn(len(soutujson.Illusts))
-			pom2 := soutujson.Illusts[rannum].ImageUrls.Large[19:]
+			pom2 := soutujson.Illusts[rannum].ImageUrls.Medium[19:]
 			ctx.SendChain(message.Image(pom1 + pom2))
 		})
 }


### PR DESCRIPTION
1.代理域名从.cat替换成.re;
2.Large尺寸图无法在PC QQ看见，已更改成Medium尺寸