### PR TITLE
从url正则中去除用字

### DIFF
--- a/plugin/manager/manager.go
+++ b/plugin/manager/manager.go
@@ -294,7 +294,7 @@ func init() { // 插件主体
 			var url, alert string
 			switch len(dateStrs) {
 			case 4:
-				url = dateStrs[2]
+				url = strings.TrimPrefix(dateStrs[2], "用")
 				alert = dateStrs[3]
 			case 3:
 				alert = dateStrs[2]


### PR DESCRIPTION
从url正则中去除用字,以防止url中包含用字前缀导致图片显示失败