### PR TITLE
群聊中撤回消息

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ zerobot [-h] [-n nickname] [-t token] [-u url] [-p prefix] [-d|w] [-c|s config.j
 
   - [ ] 同意好友请求
 
-  - [ ] 撤回[@xxx] [xxx]
+  - [x] 对信息回复: 撤回
 
   - [ ] 警告[@xxx]
 

--- a/plugin/manager/manager.go
+++ b/plugin/manager/manager.go
@@ -268,14 +268,10 @@ func init() { // 插件主体
 	// 权限够的话，可以把请求撤回的消息也一并撤回
 	engine.OnRegex(`^\[CQ:reply,id=(-?\d+)\].*撤回$`, zero.AdminPermission, zero.OnlyGroup).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
-			logrus.Infoln("[manager] 要撤回的的消息ID:", ctx.State["regex_matched"].([]string)[1])
-			logrus.Infoln("[manager] 请求撤回的消息ID:", ctx.Event.MessageID)
-			go func(i message.MessageID) {
-				ctx.DeleteMessage(i)
-			}(message.NewMessageIDFromString(ctx.State["regex_matched"].([]string)[1]))
-			go func(i message.MessageID) {
-				ctx.DeleteMessage(i)
-			}(message.NewMessageIDFromInteger(ctx.Event.MessageID.(int64)))
+			// 删除需要撤回的消息ID
+			ctx.DeleteMessage(message.NewMessageIDFromString(ctx.State["regex_matched"].([]string)[1]))
+			// 删除请求撤回的消息ID
+			//ctx.DeleteMessage(message.NewMessageIDFromInteger(ctx.Event.MessageID.(int64)))
 		})
 	// 群聊转发
 	engine.OnRegex(`^群聊转发.*?(\d+)\s(.*)`, zero.SuperUserPermission).SetBlock(true).

--- a/plugin/manager/manager.go
+++ b/plugin/manager/manager.go
@@ -269,7 +269,7 @@ func init() { // 插件主体
 	engine.OnRegex(`^\[CQ:reply,id=(-?\d+)\].*撤回$`, zero.AdminPermission, zero.OnlyGroup).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			logrus.Infoln("[manager] 要撤回的的消息ID:", ctx.State["regex_matched"].([]string)[1])
-			logrus.Infoln("[manager] 撤回的请求的消息ID:", ctx.Event.MessageID)
+			logrus.Infoln("[manager] 请求撤回的消息ID:", ctx.Event.MessageID)
 			go func(i message.MessageID) {
 				ctx.DeleteMessage(i)
 			}(message.NewMessageIDFromString(ctx.State["regex_matched"].([]string)[1]))

--- a/plugin/manager/manager.go
+++ b/plugin/manager/manager.go
@@ -263,6 +263,20 @@ func init() { // 插件主体
 			)
 			ctx.SendChain(message.Text("嗯！不错的头衔呢~"))
 		})
+	// 撤回
+	// 群聊中直接回复消息结尾带上撤回
+	// 权限够的话，可以把请求撤回的消息也一并撤回
+	engine.OnRegex(`^\[CQ:reply,id=(-?\d+)\].*撤回$`, zero.AdminPermission, zero.OnlyGroup).SetBlock(true).
+		Handle(func(ctx *zero.Ctx) {
+			logrus.Infoln("[manager] 要撤回的的消息ID:", ctx.State["regex_matched"].([]string)[1])
+			logrus.Infoln("[manager] 撤回的请求的消息ID:", ctx.Event.MessageID)
+			go func(i message.MessageID) {
+				ctx.DeleteMessage(i)
+			}(message.NewMessageIDFromString(ctx.State["regex_matched"].([]string)[1]))
+			go func(i message.MessageID) {
+				ctx.DeleteMessage(i)
+			}(message.NewMessageIDFromInteger(ctx.Event.MessageID.(int64)))
+		})
 	// 群聊转发
 	engine.OnRegex(`^群聊转发.*?(\d+)\s(.*)`, zero.SuperUserPermission).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {


### PR DESCRIPTION
群聊中直接回复需要撤回的消息来进行撤回,如果机器人权限足够的话,可以把请求撤回的消息一并撤回