### PR TITLE
HowToCook function Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,16 @@ print("run[CQ:image,file="+j["img"]+"]")
 
 </details>
 <details>
+  <summary>程序员做饭指南</summary>
+
+  `import _ "github.com/FloatTech/ZeroBot-Plugin/plugin/dish"`
+
+  - [x] 怎么做 | 烹饪[菜名]
+
+  - [x] 随机菜谱 | 随便做点菜
+
+</details>
+<details>
   <summary>多功能抽签</summary>
 
   `import _ "github.com/FloatTech/ZeroBot-Plugin/plugin/drawlots"`

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ import (
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/dailynews"        // 今日早报
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/danbooru"         // DeepDanbooru二次元图标签识别
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/diana"            // 嘉心糖发病
+	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/dish"             // 程序员做饭指南
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/drawlots"         // 多功能抽签
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/dress"            // 女装
 	_ "github.com/FloatTech/ZeroBot-Plugin/plugin/drift_bottle"     // 漂流瓶

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -73,20 +73,20 @@ func init() {
 			strings.Contains(dishName, "\\") ||
 			strings.Contains(dishName, ";") {
 			return
-		} else {
-			var d dish
-			if err := db.Find("dishes", &d, fmt.Sprintf("WHERE name like %%%s%%", dishName)); err != nil {
-				return
-			}
-
-			ctx.SendChain(message.Text(fmt.Sprintf(
-				"已为客官%s找到%s的做法辣！\n"+
-					"原材料：%s\n"+
-					"步骤：\n"+
-					"%s",
-				name, dishName, d.Materials, d.Steps),
-			))
 		}
+
+		var d dish
+		if err := db.Find("dishes", &d, fmt.Sprintf("WHERE name like %%%s%%", dishName)); err != nil {
+			return
+		}
+
+		ctx.SendChain(message.Text(fmt.Sprintf(
+			"已为客官%s找到%s的做法辣！\n"+
+				"原材料：%s\n"+
+				"步骤：\n"+
+				"%s",
+			name, dishName, d.Materials, d.Steps),
+		))
 	})
 
 	en.OnPrefixGroup([]string{"随机菜谱", "随便做点菜"}).SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
@@ -100,6 +100,7 @@ func init() {
 		if err := db.Pick("dishes", &d); err != nil {
 			ctx.SendChain(message.Text("小店好像出错了，暂时端不出菜来惹"))
 			logrus.Warnln("[dish]随机菜谱请求出错：" + err.Error())
+			return
 		}
 
 		ctx.SendChain(message.Text(fmt.Sprintf(

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -1,0 +1,153 @@
+// Package dish 程序员做饭指南zbp版，来源Anduin2017/HowToCook
+//
+// 使用前需要先git clone https://github.com/Anduin2017/HowToCook.git /path/to/data/Dish
+package dish
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ctrl "github.com/FloatTech/zbpctrl"
+	zero "github.com/wdvxdr1123/ZeroBot"
+
+	"github.com/FloatTech/zbputils/control"
+	"github.com/FloatTech/zbputils/ctxext"
+	"github.com/wdvxdr1123/ZeroBot/message"
+)
+
+type dishMenu struct {
+	path    string
+	name    string
+	content dishContent
+}
+
+type dishContent struct {
+	materials  []string
+	operations []string
+}
+
+var (
+	dishes   = map[string]dishMenu{}
+	dishList []string
+)
+
+func scanDishes(dishesPath string) error {
+	return filepath.Walk(dishesPath, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if ext := filepath.Ext(info.Name()); strings.ToLower(ext) == ".md" {
+			dishName := strings.TrimSuffix(strings.ToLower(info.Name()), ".md")
+			dishList = append(dishList, dishName)
+			dishes[dishName] = dishMenu{path: path, name: dishName}
+		}
+
+		return nil
+	})
+}
+
+func parseDish(dishPath string) (content dishContent, e error) {
+	file, err := os.Open(dishPath)
+	if err != nil {
+		return dishContent{}, err
+	}
+	defer func() {
+		closeErr := file.Close()
+		if e == nil && closeErr != nil {
+			e = closeErr
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	var buffer []string
+	for scanner.Scan() {
+		text := scanner.Text()
+		buffer = append(buffer, text)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return dishContent{}, err
+	}
+
+	var materialStartLine, materialEndLine, operationStartLine, operationEndLine = 0, 0, 0, 0
+	for line, text := range buffer {
+		buffer[line] = strings.Replace(text, " ", "", -1)
+		buffer[line] = strings.Replace(text, "*", "", -1)
+		buffer[line] = strings.Replace(text, "-", "", -1)
+		switch text {
+		case "## 必备原料和工具":
+			materialStartLine = line + 2
+		case "## 计算":
+			materialEndLine = line - 1
+		case "## 操作":
+			operationStartLine = line + 2
+		case "## 附加内容":
+			operationEndLine = line - 1
+		default:
+		}
+	}
+
+	return dishContent{
+		materials:  buffer[materialStartLine:materialEndLine],
+		operations: buffer[operationStartLine:operationEndLine],
+	}, nil
+}
+
+func formatDish(content dishContent) (material, operation string) {
+	material = strings.Join(content.materials, "、")
+	operation = ""
+	for index, step := range content.operations {
+		operation = fmt.Sprintf("%s%d. %s", operation, index+1, step)
+		if index != len(content.operations)-1 {
+			operation = fmt.Sprintf("%s\n", operation)
+		}
+	}
+
+	return material, operation
+}
+
+func init() {
+	en := control.Register("dish", &ctrl.Options[*zero.Ctx]{
+		DisableOnDefault: false,
+		Brief:            "程序员做饭指南",
+		Help:             "- 怎么做[xxx]|[随机菜谱]",
+		PublicDataFolder: "Dish",
+	})
+
+	rootDir := en.DataFolder() + "dishes"
+	if err := scanDishes(rootDir); err != nil {
+		panic(err)
+	}
+	for _, dish := range dishList {
+		parsed, e := parseDish(dishes[dish].path)
+		if e == nil {
+			content := dishes[dish]
+			content.content = parsed
+			dishes[dish] = content
+		}
+	}
+
+	en.OnPrefix("随机菜谱").SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
+		name := ctx.NickName()
+		index := rand.Intn(len(dishes))
+		dish := dishes[dishList[index]]
+		material, operation := formatDish(dish.content)
+		ctx.SendChain(message.Text(fmt.Sprintf("客官%s这次的菜谱为%s\n原材料：%s\n做法：\n%s", name, dish.name, material, operation)))
+	})
+
+	en.OnPrefix("怎么做").SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
+		dish := ctx.State["args"].(string)
+		if content, has := dishes[dish]; has {
+			material, operation := formatDish(content.content)
+			ctx.SendChain(message.Text(fmt.Sprintf("已为客官呈上%s：\n原材料：%s\n做法：\n%s", dish, material, operation)))
+		} else {
+			ctx.SendChain(message.Text(fmt.Sprintf("没法为客官找到%s这道菜呢", dish)))
+		}
+	})
+}

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -63,11 +63,7 @@ func init() {
 
 		name := ctx.NickName()
 		dishName := ctx.State["args"].(string)
-		if strings.Contains(dishName, "'") {
-			ctx.SendChain(message.Text("不合法的输入"))
-		} else if strings.Contains(dishName, "\"") {
-			ctx.SendChain(message.Text("不合法的输入"))
-		} else if strings.Contains(dishName, "\\") {
+		if strings.Contains(dishName, "'") || strings.Contains(dishName, "\"") || strings.Contains(dishName, "\\") {
 			ctx.SendChain(message.Text("不合法的输入"))
 		} else {
 			var d dish

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -94,7 +94,7 @@ func init() {
 		name := ctx.NickName()
 		var d dish
 		if err := db.Pick("dishes", &d); err != nil {
-			ctx.SendChain(message.Text(fmt.Sprintf("小店好像出错了，暂时端不出菜来惹")))
+			ctx.SendChain(message.Text("小店好像出错了，暂时端不出菜来惹"))
 		} else {
 			ctx.SendChain(message.Text(fmt.Sprintf(
 				"已为客官%s送上%s的做法：\n"+

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -1,17 +1,12 @@
-// Package dish 程序员做饭指南zbp版，来源Anduin2017/HowToCook
-//
-// 使用前需要先git clone https://github.com/Anduin2017/HowToCook.git /path/to/data/Dish
+// Package dish 程序员做饭指南zbp版，数据来源Anduin2017/HowToCook
 package dish
 
 import (
-	"bufio"
 	"fmt"
-	"io/fs"
-	"math/rand"
-	"os"
-	"path/filepath"
-	"strings"
+	"github.com/sirupsen/logrus"
+	"time"
 
+	sql "github.com/FloatTech/sqlite"
 	ctrl "github.com/FloatTech/zbpctrl"
 	zero "github.com/wdvxdr1123/ZeroBot"
 
@@ -20,134 +15,85 @@ import (
 	"github.com/wdvxdr1123/ZeroBot/message"
 )
 
-type dishMenu struct {
-	path    string
-	name    string
-	content dishContent
-}
-
-type dishContent struct {
-	materials  []string
-	operations []string
+type dish struct {
+	ID        uint32 `db:"id"`
+	Name      string `db:"name"`
+	Materials string `db:"materials"`
+	Steps     string `db:"steps"`
 }
 
 var (
-	dishes   = map[string]dishMenu{}
-	dishList []string
+	db      = &sql.Sqlite{}
+	healthy = false
 )
-
-func scanDishes(dishesPath string) error {
-	return filepath.Walk(dishesPath, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if ext := filepath.Ext(info.Name()); strings.ToLower(ext) == ".md" {
-			dishName := strings.TrimSuffix(strings.ToLower(info.Name()), ".md")
-			dishList = append(dishList, dishName)
-			dishes[dishName] = dishMenu{path: path, name: dishName}
-		}
-
-		return nil
-	})
-}
-
-func parseDish(dishPath string) (content dishContent, e error) {
-	file, err := os.Open(dishPath)
-	if err != nil {
-		return dishContent{}, err
-	}
-	defer func() {
-		closeErr := file.Close()
-		if e == nil && closeErr != nil {
-			e = closeErr
-		}
-	}()
-
-	scanner := bufio.NewScanner(file)
-	var buffer []string
-	for scanner.Scan() {
-		text := scanner.Text()
-		buffer = append(buffer, text)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return dishContent{}, err
-	}
-
-	var materialStartLine, materialEndLine, operationStartLine, operationEndLine = 0, 0, 0, 0
-	for line, text := range buffer {
-		buffer[line] = strings.Replace(text, " ", "", -1)
-		buffer[line] = strings.Replace(text, "*", "", -1)
-		buffer[line] = strings.Replace(text, "-", "", -1)
-		switch text {
-		case "## 必备原料和工具":
-			materialStartLine = line + 2
-		case "## 计算":
-			materialEndLine = line - 1
-		case "## 操作":
-			operationStartLine = line + 2
-		case "## 附加内容":
-			operationEndLine = line - 1
-		default:
-		}
-	}
-
-	return dishContent{
-		materials:  buffer[materialStartLine:materialEndLine],
-		operations: buffer[operationStartLine:operationEndLine],
-	}, nil
-}
-
-func formatDish(content dishContent) (material, operation string) {
-	material = strings.Join(content.materials, "、")
-	operation = ""
-	for index, step := range content.operations {
-		operation = fmt.Sprintf("%s%d. %s", operation, index+1, step)
-		if index != len(content.operations)-1 {
-			operation = fmt.Sprintf("%s\n", operation)
-		}
-	}
-
-	return material, operation
-}
 
 func init() {
 	en := control.Register("dish", &ctrl.Options[*zero.Ctx]{
 		DisableOnDefault: false,
 		Brief:            "程序员做饭指南",
-		Help:             "- 怎么做[xxx]|[随机菜谱]",
+		Help:             "-怎么做[xxx]|[烹饪xxx]|[随机菜谱]|[随便做点菜]",
 		PublicDataFolder: "Dish",
 	})
 
-	rootDir := en.DataFolder() + "dishes"
-	if err := scanDishes(rootDir); err != nil {
-		panic(err)
-	}
-	for _, dish := range dishList {
-		parsed, e := parseDish(dishes[dish].path)
-		if e == nil {
-			content := dishes[dish]
-			content.content = parsed
-			dishes[dish] = content
-		}
+	db.DBPath = en.DataFolder() + "dishes.db"
+
+	if _, err := en.GetLazyData("dishes.db", true); err != nil {
+		healthy = false
+	} else if err = db.Open(time.Hour * 24); err != nil {
+		healthy = false
+	} else if err = db.Create("dishes", &dish{}); err != nil {
+		healthy = false
+	} else if count, countErr := db.Count("dishes"); countErr != nil {
+		healthy = false
+	} else {
+		logrus.Infoln("[dish]加载", count, "条菜谱")
+		healthy = true
 	}
 
-	en.OnPrefix("随机菜谱").SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
+	if !healthy {
+		logrus.Warnln("[dish]插件未能成功初始化")
+	}
+
+	en.OnPrefixGroup([]string{"怎么做", "烹饪"}).SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
+		if !healthy {
+			ctx.SendChain(message.Text("客官，本店暂未开业"))
+			return
+		}
+
 		name := ctx.NickName()
-		index := rand.Intn(len(dishes))
-		dish := dishes[dishList[index]]
-		material, operation := formatDish(dish.content)
-		ctx.SendChain(message.Text(fmt.Sprintf("客官%s这次的菜谱为%s\n原材料：%s\n做法：\n%s", name, dish.name, material, operation)))
+		dishName := ctx.State["args"].(string)
+		var d dish
+		if err := db.Find("dishes", &d, "WHERE name = '"+dishName+"'"); err != nil {
+			ctx.SendChain(message.Text(fmt.Sprintf("未能为客官%s找到%s的做法qwq", name, dishName)))
+		} else {
+			ctx.SendChain(message.Text(fmt.Sprintf(
+				"已为客官%s找到%s的做法辣！\n"+
+					"原材料：%s\n"+
+					"步骤：\n"+
+					"%s",
+				name, dishName, d.Materials, d.Steps),
+			))
+		}
 	})
 
-	en.OnPrefix("怎么做").SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
-		dish := ctx.State["args"].(string)
-		if content, has := dishes[dish]; has {
-			material, operation := formatDish(content.content)
-			ctx.SendChain(message.Text(fmt.Sprintf("已为客官呈上%s：\n原材料：%s\n做法：\n%s", dish, material, operation)))
+	en.OnPrefixGroup([]string{"随机菜谱", "随便做点菜"}).SetBlock(true).Limit(ctxext.LimitByUser).Handle(func(ctx *zero.Ctx) {
+		if !healthy {
+			ctx.SendChain(message.Text("客官，本店暂未开业"))
+			return
+		}
+
+		name := ctx.NickName()
+		var d dish
+		if err := db.Pick("dishes", &d); err != nil {
+			ctx.SendChain(message.Text(fmt.Sprintf("小店好像出错了，暂时端不出菜来惹")))
 		} else {
-			ctx.SendChain(message.Text(fmt.Sprintf("没法为客官找到%s这道菜呢", dish)))
+			ctx.SendChain(message.Text(fmt.Sprintf(
+				"已为客官%s送上%s的做法：\n"+
+					"原材料：%s\n"+
+					"步骤：\n"+
+					"%s",
+				name, d.Name, d.Materials, d.Steps),
+			))
 		}
 	})
 }


### PR DESCRIPTION
这个PR新增了一个插件：

程序员做饭指南(Anduin2017/HowToCook)集成

1. 目前采用力大砖飞的手解markdown版本，如果菜谱作者不讲武德不按照原项目规范写作，最后的效果就会很炸裂
2. 没有加入数据同步机制，需要手动将Anduin2017/HowToCook仓库克隆：
  ```shell
  git clone https://github.com/Anduin2017/HowToCook /path/to/data/Dish
  ```

增加了「随机菜谱」和「怎么做XXX」两个指令