### PR TITLE
Update guessmusic plugin

### DIFF
--- a/plugin/guessmusic/main.go
+++ b/plugin/guessmusic/main.go
@@ -32,7 +32,7 @@ var (
 	cfg config
 	// 插件主体
 	engine = control.AutoRegister(&ctrl.Options[*zero.Ctx]{
-		DisableOnDefault: false,
+		DisableOnDefault: true,
 		Brief:            "猜歌插件",
 		Help: "------bot主人指令------\n" +
 			"- 设置猜歌歌库路径 [绝对路径]\n" +


### PR DESCRIPTION
1. 修复：正确答案变小写、简体的问题
原先是把标准答案转小写、简体，然后再和输入答案比较。现在是每次比较的时候，都对标准答案和输入答案进行转换。是否要再加个变量先把转换后的标准答案存起来，比较的时候用。


2. 抽选歌曲的时候，只抽选本地已经下载好的歌曲
原先抽歌的时候有概率会调用API,改成只从下载好的歌曲里选取


3. 将插件改为默认禁用
 因为下载的API失效了，不过依然可以通过其他方式添加歌曲

4. 新功能：提供猜歌选项
如图
![image](https://github.com/FloatTech/ZeroBot-Plugin/assets/67186678/5808bda7-6bf8-40d2-8920-a3a1bf24dfb9)
