### PR TITLE
[issues 900] Update gif plugin for image cache

### DIFF
--- a/plugin/gif/context.go
+++ b/plugin/gif/context.go
@@ -87,13 +87,13 @@ func dlrange(prefix string, end int, wg *sync.WaitGroup, exit func(error)) []str
 }
 
 // 新的上下文
-func newContext(user int64) *context {
+func newContext(user int64, atUser int64) *context {
 	c := new(context)
-	c.usrdir = datapath + "users/" + strconv.FormatInt(user, 10) + `/`
+	c.usrdir = datapath + "users/" + strconv.FormatInt(atUser, 10) + `/`
 	_ = os.MkdirAll(c.usrdir, 0755)
 	c.headimgsdir = make([]string, 2)
-	c.headimgsdir[0] = c.usrdir + "0.gif"
-	c.headimgsdir[1] = c.usrdir + "1.gif"
+	c.headimgsdir[0] = datapath + "users/" + strconv.FormatInt(atUser, 10) + ".gif"
+	c.headimgsdir[1] = datapath + "users/" + strconv.FormatInt(user, 10) + ".gif"
 	return c
 }
 

--- a/plugin/gif/logo.go
+++ b/plugin/gif/logo.go
@@ -14,9 +14,9 @@ func (cc *context) prepareLogos(s ...string) error {
 	for i, v := range s {
 		_, err := strconv.Atoi(v)
 		if err != nil {
-			err = file.DownloadTo("https://gchat.qpic.cn/gchatpic_new//--"+strings.ToUpper(v)+"/0", cc.usrdir+strconv.Itoa(i)+".gif")
+			err = file.DownloadTo("https://gchat.qpic.cn/gchatpic_new//--"+strings.ToUpper(v)+"/0", cc.headimgsdir[i])
 		} else {
-			err = file.DownloadTo("http://q4.qlogo.cn/g?b=qq&nk="+v+"&s=640", cc.usrdir+strconv.Itoa(i)+".gif")
+			err = file.DownloadTo("http://q4.qlogo.cn/g?b=qq&nk="+v+"&s=640", cc.headimgsdir[i])
 		}
 		if err != nil {
 			return err

--- a/plugin/gif/run.go
+++ b/plugin/gif/run.go
@@ -152,8 +152,9 @@ func init() { // 插件主体
 	datapath = file.BOTPATH + "/" + en.DataFolder()
 	en.OnRegex(`^(` + strings.Join(cmd, "|") + `)[\s\S]*?(\[CQ:(image\,file=([0-9a-zA-Z]{32}).*|at.+?(\d{5,11}))\].*|(\d+))$`).
 		SetBlock(true).Handle(func(ctx *zero.Ctx) {
-		c := newContext(ctx.Event.UserID)
 		list := ctx.State["regex_matched"].([]string)
+		atUserID, _ := strconv.ParseInt(list[4]+list[5]+list[6], 10, 64)
+		c := newContext(ctx.Event.UserID, atUserID)
 		err := c.prepareLogos(list[4]+list[5]+list[6], strconv.FormatInt(ctx.Event.UserID, 10))
 		if err != nil {
 			ctx.SendChain(message.Text("ERROR: ", err))


### PR DESCRIPTION
[issues 900] Update gif plugin for image cache
修改gif插件图片保存方式

头像统一保存在`user/qqid.gif`
生成的图片保存在 `user/被@的人qqid/`