### PR TITLE
修复 FullMatchRule 中调用 ctx.NickName() 的 panic 问题

### DIFF
--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -96,7 +96,7 @@ func init() {
 			return
 		}
 
-		name := ctx.NickName()
+		name := ctx.CardOrNickName(ctx.Event.UserID)
 		var d dish
 		if err := db.Pick("dish", &d); err != nil {
 			ctx.SendChain(message.Text("小店好像出错了，暂时端不出菜来惹"))


### PR DESCRIPTION
![image](https://github.com/FloatTech/ZeroBot-Plugin/assets/76832871/347e8967-631e-42a1-ab76-7d169906882f)

`PrefixRule` 的 `ctx.State` 具有 `"args"` 键，而 `FullMatchRule` 并不具有，https://github.com/FloatTech/ZeroBot-Plugin/commit/879948a5c4723d4986608ec362195e8ed48a9cd0 之后，`ctx.NickName()` 调用 `ctx.State["args"]` 时访问了不存在的键，引发 `panic`。

鉴于 `name` 变量仅用于输出用户的昵称，无需从 `args`/`at` 获取昵称，因此使用能够满足需求的 `ctx.CardOrNickName(ctx.Event.UserID)` 来获取用户群昵称或昵称。