### PR TITLE
[dish] fix: 关键词搜寻功能

### DIFF
--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -78,6 +78,7 @@ func init() {
 
 		var d dish
 		if err := db.Find("dish", &d, fmt.Sprintf("WHERE name like '%%%s%%'", dishName)); err != nil {
+			ctx.SendChain(message.Text("客官，本店没有" + dishName))
 			return
 		}
 

--- a/plugin/dish/dish.go
+++ b/plugin/dish/dish.go
@@ -77,7 +77,7 @@ func init() {
 		}
 
 		var d dish
-		if err := db.Find("dish", &d, fmt.Sprintf("WHERE name like %%%s%%", dishName)); err != nil {
+		if err := db.Find("dish", &d, fmt.Sprintf("WHERE name like '%%%s%%'", dishName)); err != nil {
 			return
 		}
 
@@ -86,7 +86,7 @@ func init() {
 				"原材料：%s\n"+
 				"步骤：\n"+
 				"%s",
-			name, dishName, d.Materials, d.Steps),
+			name, d.Name, d.Materials, d.Steps),
 		))
 	})
 


### PR DESCRIPTION
`db.Find` 所用的 `condition` 中，关键词没有被一对 `'`包裹，调用时会报错 `SQL logic error: near "%": syntax error (1)`。

返回结果时，应当返回找到的菜谱名 `d.Name`，而不是用户输入的关键词 `dishName`。

如用户输入的关键词未搜索到结果，给予提示。