### PR TITLE
fix(mcfish): 合成的鱼竿可能多给

### DIFF
--- a/plugin/mcfish/fish.go
+++ b/plugin/mcfish/fish.go
@@ -59,7 +59,7 @@ func init() {
 			for {
 				select {
 				case <-time.After(time.Second * 120):
-					ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消钓鱼")))
+					ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消购买")))
 					return
 				case e := <-recv:
 					nextcmd := e.Event.Message.String()

--- a/plugin/mcfish/fish.go
+++ b/plugin/mcfish/fish.go
@@ -147,7 +147,7 @@ func init() {
 			fishNumber = 0
 			for name, number := range fishNmaes {
 				fishNumber += number
-				msg += strconv.Itoa(number) + name + "、"
+				msg += strconv.Itoa(number) + name + " "
 			}
 			msg += ")"
 			fishNumber /= 2

--- a/plugin/mcfish/main.go
+++ b/plugin/mcfish/main.go
@@ -413,9 +413,9 @@ func (sql *fishdb) pickFishFor(uid int64, number int) (fishNames map[string]int,
 		}
 		if fishInfo.Number < i {
 			k++
-			fishInfo.Number = 0
 			i -= fishInfo.Number
 			fishNames[fishInfo.Name] += fishInfo.Number
+			fishInfo.Number = 0
 		} else {
 			fishNames[fishInfo.Name] += i
 			fishInfo.Number -= i

--- a/plugin/mcfish/pole.go
+++ b/plugin/mcfish/pole.go
@@ -383,8 +383,6 @@ func init() {
 			})
 		}
 		list := []int{0, 1, 2}
-		// 可以用于合成的鱼竿数量(取3的倍数)，note：此处未对article.Number>1的情况做处理
-		upgradeNum := (len(articles) / 3) * 3
 		check := false
 		if len(articles) > 3 {
 			msg := make(message.Message, 0, 3+len(articles))
@@ -421,7 +419,8 @@ func init() {
 						return
 					}
 					if nextcmd == "梭哈" {
-						for i := 3; i < upgradeNum; i++ {
+						// len(list)取3的倍数，表示能够用于合成鱼竿的最大数量，note：此处未对article.Number>1的情况做处理
+						for i := 3; i < (len(articles)/3)*3; i++ {
 							list = append(list, i)
 						}
 						check = true
@@ -459,6 +458,7 @@ func init() {
 				}
 			}
 		}
+		upgradeNum := len(list)
 		favorLevel := 0
 		induceLevel := 0
 		for _, index := range list {

--- a/plugin/mcfish/store.go
+++ b/plugin/mcfish/store.go
@@ -107,7 +107,7 @@ func init() {
 						"[", i, "]", info.Name, "  数量: ", info.Number, "\n"))
 				}
 			}
-			msg = append(msg, message.Text("————————\n输入对应序号进行装备,或回复“取消”取消"))
+			msg = append(msg, message.Text("————————\n输入对应序号进行出售,或回复“取消”取消"))
 			ctx.Send(msg)
 			// 等待用户下一步选择
 			sell := false
@@ -169,7 +169,7 @@ func init() {
 		for {
 			select {
 			case <-time.After(time.Second * 60):
-				ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消钓鱼")))
+				ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消出售")))
 				return
 			case e := <-recv:
 				nextcmd := e.Event.Message.String()
@@ -333,7 +333,7 @@ func init() {
 			pice += (priceList[info.Name] * discountList[info.Name] / 100) * info.Number * 8 / 10
 		}
 
-		ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("是否接受商店将以", pice, "收购全部垃圾", "?\n回答\"是\"或\"否\"")))
+		ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("是否接受回收站将以", pice, "收购全部垃圾", "?\n回答\"是\"或\"否\"")))
 		// 等待用户下一步选择
 		recv, cancel1 := zero.NewFutureEvent("message", 999, false, zero.RegexRule(`^(是|否)$`), zero.CheckUser(ctx.Event.UserID)).Repeat()
 		defer cancel1()
@@ -341,7 +341,7 @@ func init() {
 		for {
 			select {
 			case <-time.After(time.Second * 60):
-				ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消钓鱼")))
+				ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("等待超时,取消出售垃圾")))
 				return
 			case e := <-recv:
 				nextcmd := e.Event.Message.String()
@@ -462,7 +462,7 @@ func init() {
 						"[", i, "]", info.Name, "  数量:", info.Number, "  价格:", pice[i], "\n"))
 				}
 			}
-			msg = append(msg, message.Text("————————\n输入对应序号进行装备,或回复“取消”取消"))
+			msg = append(msg, message.Text("————————\n输入对应序号进行购买,或回复“取消”取消"))
 			ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, msg...))
 			// 等待用户下一步选择
 			sell := false

--- a/plugin/mcfish/store.go
+++ b/plugin/mcfish/store.go
@@ -375,6 +375,11 @@ func init() {
 				return
 			}
 		}
+		err = wallet.InsertWalletOf(uid, pice)
+		if err != nil {
+			ctx.SendChain(message.Text("[ERROR，出售垃圾失败，回收站卷款跑路了]:", err))
+			return
+		}
 		ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("出售成功,你赚到了", pice, msg)))
 	})
 	engine.OnRegex(`^购买(`+strings.Join(thingList, "|")+`)\s*(\d*)$`, getdb, refreshFish).SetBlock(true).Limit(limitSet).Handle(func(ctx *zero.Ctx) {


### PR DESCRIPTION
- 不使用梭哈功能合成鱼竿时，生成鱼竿仍然按梭哈合成计算，导致鱼竿可能多给
- 完善提示文本



问题描述： upgradeNum 参数在一开始就按照梭哈的方式进行赋值。导致使用普通合成，生成新鱼竿时鱼竿数量是按照梭哈给的（鱼竿多给了）
解决方法：改成用list[]来计算用户合成鱼竿的数量。