### PR TITLE
fix:修复出售限制未生效的问题

### DIFF
--- a/plugin/mcfish/main.go
+++ b/plugin/mcfish/main.go
@@ -791,6 +791,7 @@ func (sql *fishdb) checkCanSalesFor(uid int64, sales bool) (int, error) {
 		userInfo.Duration = time.Now().Unix()
 		userInfo.SalesPole = 0
 		userInfo.BuyTing = 0
+		userInfo.SalesFish = 0
 	}
 	if sales && userInfo.SalesPole < 5 {
 		residue = 5 - userInfo.SalesPole
@@ -825,6 +826,9 @@ func (sql *fishdb) selectCanSalesFishFor(uid int64, sales int) int {
 	_ = sql.db.Find("buff", &userInfo, "where ID = "+strconv.FormatInt(uid, 10))
 	if time.Now().Day() != time.Unix(userInfo.Duration, 0).Day() {
 		userInfo.Duration = time.Now().Unix()
+		// 在 checkCanSalesFor 也有更新buff时间，TODO：重构 *CanSalesFishFor 俩个函数
+		userInfo.SalesPole = 0
+		userInfo.BuyTing = 0
 		userInfo.SalesFish = 0
 		err := sql.db.Insert("buff", &userInfo)
 		if err != nil {

--- a/plugin/mcfish/store.go
+++ b/plugin/mcfish/store.go
@@ -194,13 +194,6 @@ func init() {
 			}
 		}
 
-		// 更新交易鱼类数量
-		if checkIsFish(thingName) {
-			err := dbdata.updateCanSalesFishFor(uid, number)
-			if err != nil {
-				ctx.SendChain(message.Text("[ERROR,记录鱼类交易数量失败，此次交易不记录]:", err))
-			}
-		}
 		records, err := dbdata.getUserThingInfo(uid, "唱片")
 		if err != nil {
 			ctx.SendChain(message.Text("[ERROR at store.go.9.1]:", err))
@@ -321,6 +314,14 @@ func init() {
 				logrus.Warnln(err)
 			}
 		}
+		// 更新交易鱼类数量
+		if checkIsFish(thingName) {
+			err := dbdata.updateCanSalesFishFor(uid, number)
+			if err != nil {
+				ctx.SendChain(message.Text("[ERROR,记录鱼类交易数量失败，此次交易不记录]:", err))
+			}
+		}
+
 		ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("成功出售", thingName, "：", number, "个", ",你赚到了", pice*number, msg)))
 	})
 	engine.OnRegex(`^出售所有垃圾`, getdb, refreshFish).SetBlock(true).Limit(limitSet).Handle(func(ctx *zero.Ctx) {
@@ -532,13 +533,6 @@ func init() {
 			}
 		}
 
-		// 更新交易鱼类数量
-		if checkIsFish(thingName) {
-			err := dbdata.updateCanSalesFishFor(uid, number)
-			if err != nil {
-				ctx.SendChain(message.Text("[ERROR,更新鱼类交易数量失败，此次交易不记录]:", err))
-			}
-		}
 		thing := thingInfos[index]
 		if thing.Number < number {
 			ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("商店数量不足")))
@@ -654,6 +648,13 @@ func init() {
 			err = dbdata.updateCurseFor(uid, "buy", 1)
 			if err != nil {
 				logrus.Warnln(err)
+			}
+		}
+		// 更新交易鱼类数量
+		if checkIsFish(thingName) {
+			err := dbdata.updateCanSalesFishFor(uid, number)
+			if err != nil {
+				ctx.SendChain(message.Text("[ERROR,更新鱼类交易数量失败，此次交易不记录]:", err))
 			}
 		}
 		ctx.Send(message.ReplyWithMessage(ctx.Event.MessageID, message.Text("你用", price, "购买了", number, thingName)))


### PR DESCRIPTION
1.  修改更新购买限制逻辑的位置
2.  - `checkCanSalesFor` & `selectCanSalesFishFor`俩个函数一个是检测出售鱼竿上限，一个是检测出售鱼上限； 
     - 暂时解决俩个函数对于buff状态更新冲突的问题；
     - 下个版本打算重构一下这部分，把俩个函数合并一下，用一个函数就够了。