### PR TITLE
fix:修复猜单词插件最后一轮无法正常发送的错误

### DIFF
--- a/plugin/wordle/wordle.go
+++ b/plugin/wordle/wordle.go
@@ -235,10 +235,6 @@ func newWordleGame(target string) func(string) (bool, []byte, error) {
 				}
 			}
 			record = append(record, s)
-			if len(record) >= cap(record) {
-				err = errTimesRunOut
-				return
-			}
 		}
 		var side = 20
 		var space = 10
@@ -269,6 +265,10 @@ func newWordleGame(target string) func(string) (bool, []byte, error) {
 			}
 		}
 		data, err = imgfactory.ToBytes(ctx.Image())
+		if len(record) >= cap(record) {
+			err = errTimesRunOut
+			return
+		}
 		return
 	}
 }


### PR DESCRIPTION
猜单词插件执行到最后一行会产生错误无法正确输出，原因是img数据为空，这里调整了代码位置来修复这个错误。