### PR TITLE
doc(README): 修复 README 中的 star history 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
   | [onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin) | [Mirai](https://github.com/mamoe/mirai) | yyuueexxiinngg | 不再积极维护 |
   | [oicq/http-api](https://github.com/takayama-lily/oicq/tree/master/http-api) | [OICQ](https://github.com/takayama-lily/oicq) | takayama | 已归档不再维护 |
 
-  [![Star Trend](https://api.star-history.com/svg?repos=FloatTech/ZeroBot-Plugin&type=Timeline)](https://seladb.github.io/StarTrack-js/#/preload?r=FloatTech,ZeroBot-Plugin)
+  [![Star Trend](https://star-history.dera.page/svg?repos=FloatTech/ZeroBot-Plugin&type=Timeline)](https://seladb.github.io/StarTrack-js/#/preload?r=FloatTech,ZeroBot-Plugin)
 
 </div>
 


### PR DESCRIPTION
当前 README 中的 star history 图表因 GitHub stargazer API 限制而无法正常显示，影响项目的展示效果。本 PR 将图表地址切换到无 API token 的新数据源，使图表恢复正常渲染。